### PR TITLE
S03: Fix Path Used to Serve React App

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,20 +4,6 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 from app.api import endpoints
 
-#TEMP: Looking for cause of Runtime Error.
-print("✅ FastAPI is booting...")
-print("PYTHONPATH:", os.getenv("PYTHONPATH"))
-
-#Check for the frontend files, which should be in the /static path, logging results
-frontend_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "static"))
-print("✅ Looking for static frontend at:", frontend_path)
-
-if not os.path.exists(frontend_path):
-    print("❌ Static directory does not exist!")
-else:
-    print("✅ Static directory found. Contents:")
-    print(os.listdir(frontend_path))
-
 
 app = FastAPI()
 
@@ -38,5 +24,5 @@ app.add_middleware(
 app.include_router(endpoints.router)
 
 # Serve React build from / (root)
-frontend_path = os.path.join(os.path.dirname(__file__), "static")
+frontend_path = os.path.join(os.path.dirname(__file__), ".." "static")
 app.mount("/", StaticFiles(directory=frontend_path, html=True), name="static")


### PR DESCRIPTION
Included in this PR:
- Corrected pathing to the frontend app so FastAPI can serve it up at "/"
- Removed temporary logging.